### PR TITLE
Available jobs could be added to dashboards

### DIFF
--- a/client/src/pages/availableJob.tsx
+++ b/client/src/pages/availableJob.tsx
@@ -51,7 +51,6 @@ const AvailableJobs = () => {
   // Method to fetch the jobs
   const fetchAvailableJobs = async () => {
     try {
-      console.log("Fetching available jobs..."); 
       const res = await api.get<Job[]>(`http://localhost:5001/api/jobs/`);
       console.log("Response data:", res.data); 
       setJobs(res.data);
@@ -59,6 +58,32 @@ const AvailableJobs = () => {
       console.error("Error fetching jobs", err);
     }
   };
+
+  // Method to apply to job
+  const handleApply = async (jobId: string) => {
+    const token = localStorage.getItem("token");
+    if (!token) {
+      alert("You must be logged in to apply.");
+      return;
+    }
+
+    try {
+      await api.post(
+        "/jobs/apply",
+        { jobId },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+      alert("Application submitted successfully.");
+    } catch (err) {
+      console.error("Error applying to job:", err);
+      alert("Failed to apply. You might have already applied.");
+    }
+  };
+
   
 
   //  Method to sort the jobs
@@ -94,33 +119,31 @@ const AvailableJobs = () => {
     <div className="dashboard-container">
       <Navbar />
 
-      {/* Add New Job */}
+      {/* Add Job Button */}
       <div className="new-job-form-launch">
         <button className="submit-button" onClick={() => setIsFormOpen(true)}>
           + Add a Job
         </button>
       </div>
 
+      {/* Add Job Modal */}
       {isFormOpen && (
         <div className="add-job-modal-overlay">
           <div className="add-job-modal">
             <h2>Add a New Job</h2>
             <input
-              type="text"
               className="form-input"
               placeholder="Company"
               value={newCompany}
               onChange={(e) => setNewCompany(e.target.value)}
             />
             <input
-              type="text"
               className="form-input"
               placeholder="Position"
               value={newPosition}
               onChange={(e) => setNewPosition(e.target.value)}
             />
             <input
-              type="text"
               className="form-input"
               placeholder="Location"
               value={newLocation}
@@ -129,7 +152,8 @@ const AvailableJobs = () => {
             <select
               value={newJobType}
               className="form-select"
-              onChange={(e) => setNewJobType(e.target.value as Job["jobType"])}>
+              onChange={(e) => setNewJobType(e.target.value as Job["jobType"])}
+            >
               <option value="Full-time">Full-time</option>
               <option value="Part-time">Part-time</option>
               <option value="Remote">Remote</option>
@@ -142,36 +166,32 @@ const AvailableJobs = () => {
               onChange={(e) => setNewDescription(e.target.value)}
               rows={4}
             />
-
             <div className="modal-buttons">
               <button
                 className="submit-button"
                 onClick={async () => {
-                  if (!newCompany || !newPosition) return alert("Please fill in both fields");
+                  if (!newCompany || !newPosition) {
+                    alert("Please fill in required fields.");
+                    return;
+                  }
                   try {
-                    await api.post<Job[]>(`http://localhost:5001/api/jobs/`, {
+                    await api.post("/jobs", {
                       company: newCompany,
                       position: newPosition,
                       location: newLocation,
                       jobType: newJobType,
                       description: newDescription,
-                    }, {
-                      headers: {
-                        'Content-Type': 'application/json',
-                      }
                     });
-
-                    // Reset & close
+                    setIsFormOpen(false);
                     setNewCompany("");
                     setNewPosition("");
                     setNewLocation("");
                     setNewJobType("Full-time");
                     setNewDescription("");
-                    setIsFormOpen(false);
                     fetchAvailableJobs();
                   } catch (err) {
                     console.error("Error adding job:", err);
-                    alert("Failed to add job");
+                    alert("Failed to add job.");
                   }
                 }}
               >
@@ -185,20 +205,18 @@ const AvailableJobs = () => {
         </div>
       )}
 
-
-      
-
-      {/* Job List */}
-      <h2 className="job-list-header">Open Jobs</h2>
-      {/* Filter & Sort */}
+      {/* Sort Dropdown */}
       <div className="filter-container">
         <select className="sort-dropdown" onChange={(e) => setSortOrder(e.target.value)}>
           <option value="date">Newest First</option>
           <option value="alpha">A-Z</option>
         </select>
       </div>
+
+      {/* Job Listings */}
+      <h2 className="job-list-header">Open Jobs</h2>
       <div className="job-list">
-        {sortedJobs.length === 0 ? (
+        {currentJobs.length === 0 ? (
           <p>No jobs are open yet!</p>
         ) : (
           currentJobs.map((job) => (
@@ -209,12 +227,16 @@ const AvailableJobs = () => {
                 <button
                   className="trash-button"
                   onClick={() => setJobIdToDelete(job._id)}
-                  title="Delete job"
                 >
                   🗑️
                 </button>
+                <button
+                  className="apply-button"
+                  onClick={() => handleApply(job._id)}
+                >
+                  Apply to this job
+                </button>
               </div>
-
               <p><strong>🏢 Company:</strong> {job.company}</p>
               {job.location && <p><strong>📍 Location:</strong> {job.location}</p>}
               <p><strong>🕒 Posted:</strong> {new Date(job.createdAt).toLocaleDateString()}</p>
@@ -224,40 +246,46 @@ const AvailableJobs = () => {
         )}
       </div>
 
+      {/* Pagination */}
       {totalPages > 1 && (
         <div className="pagination-container">
-          {Array.from({ length: totalPages }, (_, index) => (
+          {Array.from({ length: totalPages }, (_, i) => (
             <button
-              key={index}
-              className={`page-button ${currentPage === index + 1 ? 'active' : ''}`}
-              onClick={() => setCurrentPage(index + 1)}
+              key={i}
+              className={`page-button ${currentPage === i + 1 ? "active" : ""}`}
+              onClick={() => setCurrentPage(i + 1)}
             >
-              {index + 1}
+              {i + 1}
             </button>
           ))}
         </div>
       )}
 
+      {/* Confirm Deletion */}
       {jobIdToDelete && (
         <div className="deletion-confirm-overlay">
           <div className="deletion-confirm-content">
             <p>Are you sure you want to delete this job?</p>
             <div className="modal-buttons">
-              <button className="confirm-button" onClick={async () => {
-                await handleDelete(jobIdToDelete);
+              <button
+                className="confirm-button"
+                onClick={async () => {
+                  await handleDelete(jobIdToDelete);
                   setJobIdToDelete(null);
-                }}>
+                }}
+              >
                 Confirm
               </button>
-              <button className="cancel-button" onClick={() => setJobIdToDelete(null)}>
+              <button
+                className="cancel-button"
+                onClick={() => setJobIdToDelete(null)}
+              >
                 Cancel
               </button>
             </div>
           </div>
         </div>
       )}
-      
-
     </div>
   );
 };

--- a/client/src/pages/availableJob.tsx
+++ b/client/src/pages/availableJob.tsx
@@ -36,7 +36,12 @@ const AvailableJobs = () => {
   const [newJobType, setNewJobType] = useState<Job["jobType"]>("Full-time");
   const [newDescription, setNewDescription] = useState("");
 
+  // Job form opener
   const [isFormOpen, setIsFormOpen] = useState(false);
+
+  // Job page handle
+  const [currentPage, setCurrentPage] = useState(1);
+  const jobsPerPage = 10;
  
   useEffect(() => {
     fetchAvailableJobs();
@@ -65,6 +70,13 @@ const AvailableJobs = () => {
     }
     return 0;
   });
+
+  // Pagination logic
+  const indexOfLastJob = currentPage * jobsPerPage;
+  const indexOfFirstJob = indexOfLastJob - jobsPerPage;
+  const currentJobs = sortedJobs.slice(indexOfFirstJob, indexOfLastJob);
+
+  const totalPages = Math.ceil(sortedJobs.length / jobsPerPage);
 
   // Deleting a job by id
   const handleDelete = async (jobId: string) => {
@@ -189,7 +201,7 @@ const AvailableJobs = () => {
         {sortedJobs.length === 0 ? (
           <p>No jobs are open yet!</p>
         ) : (
-          sortedJobs.map((job) => (
+          currentJobs.map((job) => (
             <div key={job._id} className="job-entry">
               <div className="job-header">
                 {job.jobType && <span className="job-tag">{job.jobType}</span>}
@@ -211,6 +223,20 @@ const AvailableJobs = () => {
           ))
         )}
       </div>
+
+      {totalPages > 1 && (
+        <div className="pagination-container">
+          {Array.from({ length: totalPages }, (_, index) => (
+            <button
+              key={index}
+              className={`page-button ${currentPage === index + 1 ? 'active' : ''}`}
+              onClick={() => setCurrentPage(index + 1)}
+            >
+              {index + 1}
+            </button>
+          ))}
+        </div>
+      )}
 
       {jobIdToDelete && (
         <div className="deletion-confirm-overlay">

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -39,7 +39,9 @@ const Dashboard = () => {
       const token = localStorage.getItem("token");
       if (!token) throw new Error("No token found");
 
-      const res = await api.get<Job[]>(`http://localhost:5001/api/jobs/`);
+      const res = await api.get<Job[]>(`http://localhost:5001/api/jobs/applied`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
 
       setJobs(res.data);
     } catch (error) {
@@ -51,6 +53,16 @@ const Dashboard = () => {
   const total = jobs.length;
   const interviews = jobs.filter((job) => job.status === "interview").length;
   const rejections = jobs.filter((job) => job.status === "rejected").length;
+
+  // Sorting
+  const sortedJobs = [...jobs].sort((a, b) => {
+    if (sortOrder === "date") {
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    } else if (sortOrder === "alpha") {
+      return a.position.localeCompare(b.position);
+    }
+    return 0;
+  });
 
   return (
     <div className="dashboard-container">
@@ -73,6 +85,31 @@ const Dashboard = () => {
           <li><strong>Interviews Scheduled:</strong> {interviews}</li>
           <li><strong>Rejected:</strong> {rejections}</li>
         </ul>
+      </div>
+
+      {/* Sort Option */}
+      <div className="filter-container">
+        <select className="sort-dropdown" onChange={(e) => setSortOrder(e.target.value)}>
+          <option value="date">Newest First</option>
+          <option value="alpha">A-Z</option>
+        </select>
+      </div>
+
+      {/* Job List */}
+      <h2 className="job-list-header">Your Applied Jobs</h2>
+      <div className="job-list">
+        {sortedJobs.length === 0 ? (
+          <p>No applications yet. Go apply to some jobs!</p>
+        ) : (
+          sortedJobs.map((job) => (
+            <div key={job._id} className="job-entry">
+              <h3>{job.position}</h3>
+              <p><strong>Company:</strong> {job.company}</p>
+              {job.status && <p><strong>Status:</strong> {job.status}</p>}
+              <p><strong>Applied:</strong> {new Date(job.createdAt).toLocaleDateString()}</p>
+            </div>
+          ))
+        )}
       </div>
 
 

--- a/client/src/styles/availableJob.css
+++ b/client/src/styles/availableJob.css
@@ -83,6 +83,7 @@
 
 .add-job-modal {
   background: white;
+  margin-top: 50px;
   padding: 2rem;
   width: 90%;
   max-width: 600px;

--- a/client/src/styles/availableJob.css
+++ b/client/src/styles/availableJob.css
@@ -139,6 +139,22 @@
   color: white;
 }
 
+/* ==================================== Apply to a job ====================================*/
+
+.apply-button {
+  background-color: #007bff;
+  color: white;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 4px;
+  margin-top: 10px;
+  cursor: pointer;
+}
+
+.apply-button:hover {
+  background-color: #0056b3;
+}
+
 /* ==================================== Filter Container ====================================*/
 .filter-container{
   width: 100%;

--- a/client/src/styles/availableJob.css
+++ b/client/src/styles/availableJob.css
@@ -22,13 +22,20 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 1.5rem;
+  row-gap: 1.5rem;
+  column-gap: 1.5rem;
   padding: 1rem;
+  width: 800px;
+  height: 600px;
+  overflow-y: auto;
+  border: 1px solid #ccc;
+  background-color: #f9f9f9;
 }
 
 .job-entry {
   width: 100%;
-  max-width: 48%;
+  max-width: 380px;
+  min-height: 200px;
   background: #ffffff;
   border: 1px solid #dedede;
   border-left: 4px solid #00be5f;
@@ -37,6 +44,9 @@
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.05);
   transition: all 0.2s ease;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 @media (max-width: 768px) {

--- a/client/src/styles/availableJob.css
+++ b/client/src/styles/availableJob.css
@@ -19,11 +19,9 @@
 /* ==================================== Job List & Entries ====================================*/
 
 .job-list {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  row-gap: 1.5rem;
-  column-gap: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr); /* 2 fixed columns */
+  gap: 1.5rem;
   padding: 1rem;
   width: 800px;
   height: 600px;
@@ -33,9 +31,8 @@
 }
 
 .job-entry {
-  width: 100%;
-  max-width: 380px;
-  min-height: 200px;
+  height: 220px;     
+  max-width: 320px;
   background: #ffffff;
   border: 1px solid #dedede;
   border-left: 4px solid #00be5f;
@@ -43,11 +40,11 @@
   padding: 1.5rem;
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.05);
   transition: all 0.2s ease;
-  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 }
+
 
 @media (max-width: 768px) {
   .job-entry {

--- a/client/src/styles/availableJob.css
+++ b/client/src/styles/availableJob.css
@@ -254,3 +254,27 @@
 .filter-container {
   width: auto;
 }
+
+
+/* ==================================== Pagination ====================================*/
+.pagination-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+  gap: 0.5rem;
+}
+
+.page-button {
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  background-color: #f2f2f2;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.page-button.active {
+  background-color: #00be5f;
+  color: white;
+  border-color: #00be5f;
+}

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -19,6 +19,7 @@ interface IUser extends Document {
     friends: string[];
     friendRequests: string[];
     createdAt: Date;
+    appliedJobs: string[];
 }
 
 const UserSchema = new mongoose.Schema<IUser>({
@@ -39,6 +40,11 @@ const UserSchema = new mongoose.Schema<IUser>({
     friendCode: { type: String, unique: true},
     friends: { type: [String], default: [] },
     friendRequests: { type: [String], default: [] },
+    appliedJobs: {
+      type: [String],
+      ref: "Job",
+      default: [],
+    },
     createdAt: { type: Date, default: Date.now },
 });
 


### PR DESCRIPTION
# Pull Request: Available jobs could be added to dashboards
This pull requst regards issue #32 #34

## Summary
This pull request updates both the backend and frontend to enable the user to add the jobs from 'available Jobs' and add them to their respective dashboard page

Also, pagination of logic for 'available Jobs' page has been implemented

## Key Changes
- **User.ts**
  - User now has the 'appliedJobs' field, where the id of applied jobs are stored
- **availableJob.tsx**
  - availalbleJob now has a pagination, where the list of available jobs are shown 10 for each page.
  - Each available job has a button to apply, which will add the job to each users' 'appliedJobs' field
-**Dashboard.tsx**
  - Dashboard will show the list of 'appliedJobs' field
-**jobRoutes.ts**
  - Two endpoints have been added - 'GET /jobs/applied' and 'POST /jobs/apply'
  - GET /jobs/applied will retreive all the applied job for each user
  - POST /jobs/apply will add the job to the user dashboard

## How the web currently looks now
![image](https://github.com/user-attachments/assets/c43543d1-4e21-4c4e-9393-36e747d87576)
![image](https://github.com/user-attachments/assets/7067a75b-f952-4e8a-96db-c2c1848b0235)


## Next Steps / Future Improvements

### To Do
- Job filter option (search option using filter)
- Additional touch on the frontend side for dashboard and availableJobs

- `/resend-verification` endpoint: The API itself was implemented, but the user can't send a second verification email for now.
